### PR TITLE
fixed typo that resulted in an improper path for initrd image in grub.cfg

### DIFF
--- a/root-image/etc/grub.d/10_archlinux
+++ b/root-image/etc/grub.d/10_archlinux
@@ -88,7 +88,7 @@ menuentry "Arch Linux ${_KERNEL_PKG_} kernel" ${CLASS} {
     echo 'Loading Arch Linux ${_KERNEL_PKG_} kernel ...'
     linux ${SUBDIR}/${_KERNEL_FILE_} root=${GRUB_LINUX_ROOT_DEVICE} rw ${GRUB_LINUX_PARAMS}
     echo 'Loading Arch Linux ${_KERNEL_PKG_} kernel initramfs ...'
-    initrd ${subdir}/${_INITRAMFS_}
+    initrd ${SUBDIR}/${_INITRAMFS_}
 }
 
 EOF
@@ -114,7 +114,7 @@ menuentry "Arch Linux ${_KERNEL_PKG_} kernel (fallback initramfs)" ${CLASS} {
     echo 'Loading Arch Linux ${_KERNEL_PKG_} kernel ...'
     linux ${SUBDIR}/${_KERNEL_FILE_} root=${GRUB_LINUX_ROOT_DEVICE} rw ${GRUB_LINUX_PARAMS}
     echo 'Loading Arch Linux ${_KERNEL_PKG_} kernel fallback initramfs ...'
-    initrd ${subdir}/${_INITRAMFS_FALLBACK_}
+    initrd ${SUBDIR}/${_INITRAMFS_FALLBACK_}
 }
 
 EOF


### PR DESCRIPTION
The grub.cfg generated by the 18-05-2014 image didn't have the proper path for the initrd image. This is due to the typo in the grub template file /etc/grub.d/10_archlinux. That is fixed.
