### PR TITLE
Added "maven" to the list

### DIFF
--- a/packages.both
+++ b/packages.both
@@ -120,6 +120,7 @@ linux-atm
 linux-headers
 lsscsi
 make
+maven
 mc
 meld
 mesa


### PR DESCRIPTION
As of recently maven is required to build CyanogenMod (not sure of AOSP) and all CyanogenMod based ROMs. If the user does not have the package, when a build is initialized, he will get a bash: mvm: command not found error.