### PR TITLE
Accomodate for size increase in efiboot.img

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -224,7 +224,7 @@ make_efi() {
 # Prepare efiboot.img::/EFI for "El Torito" EFI boot mode
 make_efiboot() {
     mkdir -p ${work_dir}/iso/EFI/archiso
-    truncate -s 40M ${work_dir}/iso/EFI/archiso/efiboot.img
+    truncate -s 42M ${work_dir}/iso/EFI/archiso/efiboot.img
     mkfs.fat -n ARCHISO_EFI ${work_dir}/iso/EFI/archiso/efiboot.img
 
     mkdir -p ${work_dir}/efiboot


### PR DESCRIPTION
efiboot.img size has increased to 41.9 MB (41,943,040 bytes), which causes build to fail:

```
mount: work/efiboot: mount failed: Unknown error -1
```

Switching from [40M to 42M](https://github.com/bbqlinux/bbqiso/blob/master/build.sh#L227) works for now, (until next increase, that is).
A better way would be calculating size dynamically in script if it is possible.
